### PR TITLE
Indicator e

### DIFF
--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -303,7 +303,7 @@ study = StudyDefinition(
         anticoagulant AND
         (NOT ppi)
         """
-    )
+    ),
 
 
     ###


### PR DESCRIPTION
This adds variables for indicator C. 

The numerator and denominator for this indicator require more complicated date ranges. I can't currently think of a way to do this directly in the study definition, so will instead create an extra script to do this.