### PR TITLE
Update to .gitignore for VScode json/Mac files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 output/*
 metadata/*
 venv/
+*.json
+.DS_Store


### PR DESCRIPTION
I've amended the .gitignore file to include that annoying .DS_Store file that Macs generate and the .json debugging files that VS code generates. At the moment, it ignores *.json, but if this is going to cause problems for other reasons, I can amend it to name the specific VS code files.