### PR TITLE
fix: produce percentiles as ints

### DIFF
--- a/analysis/utilities.py
+++ b/analysis/utilities.py
@@ -306,7 +306,8 @@ def compute_deciles(
         .quantile(pd.Series(quantiles, name="percentile"))
         .reset_index()
     )
-    percentiles["percentile"] = percentiles["percentile"] * 100
+    percentiles["percentile"] = percentiles["percentile"].apply(lambda x: int(x * 100))
+
     return percentiles
 
 def get_practice_deciles(measure_table, value_column):


### PR DESCRIPTION
Not treating the percentiles as ints resulted in some percentiles not being plotted when testing for equality of the percentiles.  

This fixes this, following [this implementation ](https://github.com/ebmdatalab/datalab-pandas/blob/master/ebmdatalab/charts.py#L37)