### PR TITLE
fix: amending dependencies for combine_indicator_saturation_data_rev

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -362,18 +362,9 @@ actions:
       moderately_sensitive:
         out_csv: output/indicator_saturation_rev/indicator_saturation_*_me_no_lft/*.csv
 
-
-
-
-
-
-
-
-
-
   combine_indicator_saturation_data_rev:
     run: r:latest analysis/combine_indicator_saturation_output.R output/indicator_saturation_rev output/indicator_saturation_rev/combined
-    needs: [indicator_saturation_a_rev, indicator_saturation_b_rev, indicator_saturation_c_rev, indicator_saturation_d_rev, indicator_saturation_e_rev] #, indicator_saturation_f, indicator_saturation_g, indicator_saturation_i, indicator_saturation_k, indicator_saturation_ac, indicator_saturation_me_no_fbc, indicator_saturation_me_no_lft, indicator_saturation_li, indicator_saturation_am]
+    needs: [indicator_saturation_a_rev, indicator_saturation_b_rev, indicator_saturation_c_rev, indicator_saturation_d_rev, indicator_saturation_e_rev, indicator_saturation_f, indicator_saturation_g, indicator_saturation_i, indicator_saturation_k, indicator_saturation_ac, indicator_saturation_me_no_fbc, indicator_saturation_me_no_lft, indicator_saturation_li, indicator_saturation_am]
     outputs:
       moderately_sensitive:
         counts: output/indicator_saturation_rev/combined/*.csv


### PR DESCRIPTION
Dependencies for the `combine_indicator_saturation_data_rev` action were incomplete previously, this PR incorporates all necessary dependencies to generate the combined plots.