### PR TITLE
Quick fix to handle missing EGFR comparators/values

### DIFF
--- a/analysis/study_definition_egfr.py
+++ b/analysis/study_definition_egfr.py
@@ -39,13 +39,15 @@ study = StudyDefinition(
                                                  "rate": "universal",
                                                  "category": {
                                                      "ratios": {  # ~, =, >= , > , < , <=
+                                                        None: 0.10,
                                                          "~": 0.05,
-                                                         "=": 0.75,
+                                                         "=": 0.65,
                                                          ">=": 0.05,
                                                          ">": 0.05,
                                                          "<": 0.05,
                                                          "<=": 0.05}
                                                  },
+                                                 "incidence": 0.80,
                                              },
     ),
 

--- a/analysis/utilities.py
+++ b/analysis/utilities.py
@@ -104,7 +104,10 @@ def count_comparator_value_pairs(directory: str) -> None:
         if match_egfr_files(file.name):
             df = pd.read_feather(dirpath / file.name)
 
-            cv_pairs = [''.join(i) for i in zip(df["egfr_comparator"], df["egfr"].map(round).map(str))]
+            df['egfr_comparator'] = df['egfr_comparator'].astype('string')
+            df.fillna({'egfr_comparator': "", 'egfr': -10}, inplace=True)
+
+            cv_pairs = [''.join( i ) for i in zip(df["egfr_comparator"], df["egfr"].map(round).map(str))]
 
             comparator_value_list = comparator_value_list + cv_pairs
 


### PR DESCRIPTION
Some EGFR comparators are missing (`None`), which was causing a problem for the `count_egfr_comparators` action. The study definition was updated to include some missing values and the `utilities.py` was updated to handle these missing comparators appropriately. A value of `-1` was added at the same time for missing values.