### PR TITLE
Updating the EGFR query taking comparators into account.

### DIFF
--- a/analysis/study_definition_egfr.py
+++ b/analysis/study_definition_egfr.py
@@ -20,7 +20,11 @@ study = StudyDefinition(
         "incidence": 0.5,
     },
 
-    population=patients.all(),
+    population=patients.satisfying(
+        """
+        (egfr_between_1_and_45)
+        """
+    ),
 
     egfr=patients.with_these_clinical_events(
         codelist=egfr_codelist,
@@ -65,7 +69,7 @@ study = StudyDefinition(
     egfr_between_1_and_45 = patients.categorised_as(
         {
             "0": "DEFAULT",
-            "1": """ (egfr>=1) AND (egfr < 45) AND ( NOT egfr_comparator = '>' ) AND ( NOT egfr_comparator = '~' ) AND (NOT ( egfr = 1  AND egfr_comparator='<')) """
+            "1": """ (egfr>=1) AND (egfr < 45) AND ( NOT egfr_comparator = '>' ) AND ( NOT egfr_comparator = '~' ) AND ( NOT ( egfr = 1  AND egfr_comparator='<') ) """
         },
         return_expectations = {
             "rate": "universal",


### PR DESCRIPTION
After obtaining the comparator information, and looking at what kind of comparator/value pairs exist in a sample of the real data, a new definition of `egfr_between_1_and_45` has been implemented.

We are hoping that this will **include egfr values >=1 and < 45**.

Values that we are not setting to include are:
* negative or missing egfr vales (irrespective of comparator)
* egfr values of 0 (irrespective of comparator)
* egfr values that are have a comparator of `>` or '~'
* unreasonably high egfr values (greater than 200/300?)
* egfr values of <1