### PR TITLE
New actions to debug indicator K denominator

### DIFF
--- a/analysis/check_indicator_k_denominator.py
+++ b/analysis/check_indicator_k_denominator.py
@@ -1,0 +1,3 @@
+from utilities import check_indicator_k_denominator, OUTPUT_DIR
+
+check_indicator_k_denominator(OUTPUT_DIR)

--- a/analysis/study_definition_egfr.py
+++ b/analysis/study_definition_egfr.py
@@ -1,0 +1,92 @@
+from cohortextractor import (
+    StudyDefinition,
+    patients,
+    Measure
+)
+
+# import os
+
+from codelists import *
+# from co_prescribing_variables import create_co_prescribing_variables
+
+start_date = "2019-09-01"
+end_date = "2021-07-01"
+
+study = StudyDefinition(
+    index_date = end_date,
+    default_expectations={
+        "date": {"earliest": start_date, "latest": end_date},
+        "rate": "uniform",
+        "incidence": 0.5,
+    },
+
+    population=patients.all(),
+
+    oral_nsaid=patients.with_these_medications(
+        codelist=oral_nsaid_codelist,
+        find_last_match_in_period=True,
+        returning="binary_flag",
+        between=["index_date - 3 months", "index_date"],
+    ),
+
+    egfr=patients.with_these_clinical_events(
+        codelist=egfr_codelist,
+        find_last_match_in_period=True,
+        returning="numeric_value",
+        on_or_before="index_date - 3 months",
+        return_expectations={
+            "float": {"distribution": "normal", "mean": 35, "stddev": 20},
+            "incidence": 0.5,
+        },
+    ),
+
+    # https://docs.opensafely.org/study-def-variables/#cohortextractor.patients.comparator_from
+    egfr_comparator=patients.comparator_from("egfr",
+                                             return_expectations={
+                                                 "rate": "universal",
+                                                 "category": {
+                                                     "ratios": {  # ~, =, >= , > , < , <=
+                                                        None: 0.10,
+                                                         "~": 0.05,
+                                                         "=": 0.65,
+                                                         ">=": 0.05,
+                                                         ">": 0.05,
+                                                         "<": 0.05,
+                                                         "<=": 0.05}
+                                                 },
+                                                 "incidence": 0.80,
+                                             },
+    ),
+
+
+    egfr_between_1_and_45 = patients.categorised_as(
+        {
+            "0": "DEFAULT",
+            "1": """ (egfr>=1) AND (egfr < 45) AND ( NOT egfr_comparator = '>' ) AND ( NOT egfr_comparator = '>=' ) AND ( NOT egfr_comparator = '~' ) AND ( NOT ( egfr = 1  AND egfr_comparator='<') ) """
+        },
+        return_expectations = {
+            "rate": "universal",
+            "category": {
+                        "ratios": {
+                            "0": 0.94,
+                            "1": 0.06,
+                                }
+                        },
+            },
+    ),
+
+
+    indicator_k_denominator=patients.satisfying(
+        """
+        egfr_between_1_and_45 = 1
+        """,
+    ),
+
+    indicator_k_numerator=patients.satisfying(
+        """
+        ( egfr_between_1_and_45 = 1 ) AND
+        oral_nsaid
+        """,
+    ),
+
+)

--- a/project.yaml
+++ b/project.yaml
@@ -28,7 +28,20 @@ actions:
     outputs:
       highly_sensitive:
         cohort: output/input_ethnicity.feather
-      
+ 
+  generate_study_population_egfr:
+    run: cohortextractor:latest generate_cohort --study-definition study_definition_egfr --output-format feather
+    outputs:
+      highly_sensitive:
+        cohort: output/input_egfr.feather
+  
+  check_indicator_k_definition:
+    run: python:latest python analysis/check_indicator_k_denominator.py
+    needs: [generate_study_population_egfr]
+    outputs:
+      moderately_sensitive:
+        cohort: output/new-indicator-k_denominator-check.csv
+
   join_ethnicity_region:
     run: python:latest python analysis/join_ethnicity_region.py
     needs: [generate_study_population_1, generate_study_population_2, generate_study_population_3, generate_study_population_ethnicity]


### PR DESCRIPTION
The previous version of the PINCER analysis showed that all patients are assigned to `indicator_k_denominator` despite `egfr_between_1_and_45` operating as required with regards to assessing the egfr value. To debug this, we have added:

1. a new study definition (`analysis/study_definition_egfr.py`) to extract egfr data and associated indicator k variables (e.g., `oral_nsaid`) using alternative functionality (`egfr_between_1_and_45 = 1` rather than `egfr_between_1_and_45`) to define `indicator_k_denominator`
2. an action to `project.yaml` to generate crosstab counts for `egfr_between_1_and_45` and `indicator_k_denominator`
3. several new functions to `utilities.py` to support (2).