### PR TITLE
Comparing different definitions of indicator_k_denominator

### DIFF
--- a/analysis/check_indicator_k_denominator.py
+++ b/analysis/check_indicator_k_denominator.py
@@ -1,3 +1,5 @@
-from utilities import check_indicator_k_denominator, OUTPUT_DIR
+from utilities import check_indicator_k_denominator, compare_indicator_k_columns, OUTPUT_DIR
 
 check_indicator_k_denominator(OUTPUT_DIR)
+
+compare_indicator_k_columns(OUTPUT_DIR)

--- a/project.yaml
+++ b/project.yaml
@@ -43,10 +43,11 @@ actions:
   
   check_indicator_k_definition:
     run: python:latest python analysis/check_indicator_k_denominator.py
-    needs: [generate_study_population_egfr]
+    needs: [generate_study_population_1, generate_study_population_2, generate_study_population_3, generate_study_population_egfr]
     outputs:
       moderately_sensitive:
-        cohort: output/new-indicator-k_denominator-check.csv
+        check1: output/new-indicator-k_denominator-check.csv
+        check2: output/new-indicator-k_denominator-match-counts.csv
 
   join_ethnicity_region:
     run: python:latest python analysis/join_ethnicity_region.py
@@ -62,7 +63,7 @@ actions:
       moderately_sensitive:
         cohort: output/EGFR_*.csv
         
-  
+
   calculate_numerators:
     run: python:latest python analysis/calculate_numerators.py
     needs: [join_ethnicity_region]


### PR DESCRIPTION
To help debug the issue that we've seen with `indicator_k_denominator` always being `True`, this PR includes new functionality to compare the original specification of `indicator_k_denominator` with the new one.

The original version is provided below (`indicator_k_denominator` still uses this definition): 

```
    indicator_k_denominator = patients.satisfying(
        """
        egfr_between_1_and_45
        """,
    ),
```

The new version is provided below (`indicator_k_denominator_new` uses this definition): 

```
    indicator_k_denominator=patients.satisfying(
        """
        egfr_between_1_and_45 = 1
        """,
    ),
```

NB. The renaming of the new version to `indicator_k_denominator_new` is done in the `compare_indicator_k_columns()` function in `utilities.py`.

