### PR TITLE
Updating slope plot for demographic aggregates to include overall mean

### DIFF
--- a/analysis/generate_demographic_slope_plot.R
+++ b/analysis/generate_demographic_slope_plot.R
@@ -8,7 +8,7 @@ library(ggrepel)
 
 file_in = "output/demographic_aggregates.csv"
 
-d_in = read_csv( file_in, show_col_types = FALSE )
+d_in = read_csv( file_in )
 
 d_toplot = d_in %>%
     mutate( delta = post_mean - pre_mean ) %>% 


### PR DESCRIPTION
Overall means have been added to the plots illustrating pre-/post-pandemic indicator rates for the different demographic groups. These are just means of means at the moment, but these should be replaced by the weighted means to represent the overall population correctly.