### PR TITLE
Fixing missing values from mean calculations for demographic groups

### DIFF
--- a/analysis/generate_demographic_slope_plot.R
+++ b/analysis/generate_demographic_slope_plot.R
@@ -34,7 +34,7 @@ d_toplot = d_in %>%
 
 d_averages = d_toplot %>% 
     group_by( indicator, demographic, indicator_set, timepoint_order )  %>% 
-    summarise( mean = mean( rate ) )
+    summarise( mean = mean( rate, na.rm = TRUE ) )
 
 
 ### 


### PR DESCRIPTION
Some mean values for the demographic X indicator slope plots (Supplementary Figures 1-3 in the descriptive PINCER paper) were not being calculated properly due to missing values. This PR includes an additional `na.rm = TRUE` parameter in the `mean()` function in `generate_demographic_slope_plot.R` that means that `NA`s will be removed before the mean is calculated. 