### PR TITLE
Adding bash script for figure modification

### DIFF
--- a/bin/do_cropping.sh
+++ b/bin/do_cropping.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+### Modified figures generated for publication
+### Journal: BMJ Medicine
+### Includes:
+### - resizing
+### - removing white space
+### - adding panel labels
+### - combining panels vertically into one plot
+
+# TRIM and LABEL (if required)
+convert -trim -background white -gravity center -extent 7500x5800 output/figures/combined_plot_gi_bleed.png output/figures/combined_plot_gi_bleed+trimmed.png
+convert output/figures/combined_plot_gi_bleed+trimmed.png -gravity NorthWest -pointsize 180 -annotate +1000+750 '(a)' output/figures/combined_plot_gi_bleed+trimmed+labelled.png
+
+convert -trim -background white -gravity center -extent 7500x3000 output/figures/combined_plot_prescribing.png output/figures/combined_plot_prescribing+trimmed.png
+convert output/figures/combined_plot_prescribing+trimmed.png -gravity NorthWest -pointsize 180 -annotate +1000+300 '(b)' output/figures/combined_plot_prescribing+trimmed+labelled.png
+
+convert -trim -background white -gravity center -extent 7500x5500 output/figures/combined_plot_monitoring.png output/figures/figure2.png
+
+# COMBINE
+convert output/figures/combined_plot_gi_bleed+trimmed+labelled.png output/figures/combined_plot_prescribing+trimmed+labelled.png -append output/figures/figure1ab.png
+
+# MOGRIFY
+magick mogrify -format tiff output/figures/figure1ab.png
+magick mogrify -format tiff output/figures/figure2.png
+
+rm output/figures/*+trimmed*
+rm output/figures/figure1ab.png
+rm output/figures/figure2.png
+
+

--- a/bin/do_cropping_v1.sh
+++ b/bin/do_cropping_v1.sh
@@ -24,7 +24,7 @@ convert output/figures/combined_plot_gi_bleed+trimmed+labelled.png output/figure
 magick mogrify -format tiff output/figures/figure1ab.png
 magick mogrify -format tiff output/figures/figure2.png
 
-rm output/figures/*+trimmed*
+rm output/figures/*+trimmed*.png
 rm output/figures/figure1ab.png
 rm output/figures/figure2.png
 

--- a/bin/do_cropping_v2.sh
+++ b/bin/do_cropping_v2.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+### Modified figures generated for publication
+### Journal: BMJ Medicine
+### Includes:
+### - resizing
+### - removing white space
+### - adding panel labels
+### - combining panels vertically into one plot
+### Post acceptance, the journal asked for the figures in PDF format.
+
+# TRIM and LABEL (if required)
+cp output/figures/combined_plot_gi_bleed.pdf output/figures/Figure1a.pdf
+cp output/figures/combined_plot_prescribing.pdf output/figures/Figure1b.pdf
+cp output/figures/combined_plot_monitoring.pdf output/figures/Figure2.pdf
+
+


### PR DESCRIPTION
This PR contains a bash script `do_cropping.sh` that amends the figures generated by the notebooks, as required by BMJ Medicine. As this is an OpenSAFELY paper, this script cannot live in the `output/` directory so it is saved to a `bin/` directory. 

This includes modifications to the resulting files, including:
- resizing
- removing white space
- adding panel labels
- combining panels vertically into one plot

The cropping script has been written for the plots that have been generated at 300dpi (resolution requested by BMJ Medicine). The necessary 300dpi figures are generated locally (as they combine the TPP and EMIS data); so this script will only work if 300dpi figures have been generated locally.